### PR TITLE
colorful-alwaysフラグを追加(やっつけ)

### DIFF
--- a/cmd/PrintUtils.go
+++ b/cmd/PrintUtils.go
@@ -93,7 +93,7 @@ func PaddingPrint(text string, c int) {
 	// 色の乱数，SEEDは時間
 	rand.Seed(time.Now().UnixNano())
 
-	if colorful {
+	if colorful || colorful_always {
 		if colorful_always {
 			color.NoColor = false
 		}

--- a/cmd/PrintUtils.go
+++ b/cmd/PrintUtils.go
@@ -94,6 +94,10 @@ func PaddingPrint(text string, c int) {
 	rand.Seed(time.Now().UnixNano())
 
 	if colorful {
+		if colorful_always {
+			color.NoColor = false
+		}
+
 		// カラフルなやつ
 		for _, v := range []rune(text) {
 			idx := rand.Intn(len(FrontColors))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,7 +65,7 @@ var duration string
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&colorful, "colorful", false, "カラフルにします")
-	rootCmd.PersistentFlags().BoolVar(&colorful_always, "colorful-always", false, "colorfulフラグ有効時、パイプやリダイレクト時にもCOLOR_CODEが適用されるよう強制します")
+	rootCmd.PersistentFlags().BoolVarP(&colorful_always, "colorful-always", "C", false, "colorfulフラグ有効時、パイプやリダイレクト時にもCOLOR_CODEが適用されるよう強制します")
 	rootCmd.PersistentFlags().StringVarP(&reqWidth, "reqWidth", "w", "auto", "表示幅です．autoにすると端末幅を取得します")
 	rootCmd.PersistentFlags().BoolVar(&overwrite, "overwrite", false, "複数回出力するときに同じ場所に上書きし続けます")
 	rootCmd.PersistentFlags().StringVarP(&count, "count", "n", "1", "指定回数出力します．infか-1を指定すると無限になります")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,17 +58,17 @@ func Execute() {
 	}
 }
 
-var colorful, overwrite bool
+var colorful, colorful_always, overwrite bool
 var reqWidth string
 var count string
 var duration string
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&colorful, "colorful", false, "カラフルにします")
+	rootCmd.PersistentFlags().BoolVar(&colorful_always, "colorful-always", false, "colorfulフラグ有効時、パイプやリダイレクト時にもCOLOR_CODEが適用されるよう強制します")
 	rootCmd.PersistentFlags().StringVarP(&reqWidth, "reqWidth", "w", "auto", "表示幅です．autoにすると端末幅を取得します")
 	rootCmd.PersistentFlags().BoolVar(&overwrite, "overwrite", false, "複数回出力するときに同じ場所に上書きし続けます")
 	rootCmd.PersistentFlags().StringVarP(&count, "count", "n", "1", "指定回数出力します．infか-1を指定すると無限になります")
 	rootCmd.PersistentFlags().StringVar(&duration, "duration", "0.5s", "繰り返しのインターバルです")
-
 	rootCmd.Flags().Int("offset", 0, "左からの距離です")
 }


### PR DESCRIPTION
--colorful-alwaysフラグでパイプ先のコマンドでもColor Codeが有効になるようにしました(´・ω・｀)
(--colorfulと--colorful-alwaysを一緒に付与すると長いので、--colorful-alwaysで一緒くたに処理してしまってもいいかも？)