### PR TITLE
owariの実行ファイルをリポジトリから削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# developer execution file
+owari
+main


### PR DESCRIPTION
気になったので PR します

- `owari` の実行ファイルがプロジェクトルートに混じっていたので削除しました
- `.gitignore` に開発者が開発用に使いそうな実行ファイル名(`owari`, `main`) を追加しました