### PR TITLE
GetLooksLengthで全角英数字or全角空白の時に長さ1を返していた不具合を修正

### DIFF
--- a/cmd/PrintUtils.go
+++ b/cmd/PrintUtils.go
@@ -31,6 +31,14 @@ var FrontColors = []color.Attribute{
 	color.FgHiYellow,
 }
 
+const zenkaku = "　ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ０１２３４５６７８９"
+
+// GetLooksLength は見た目上のテキストの長さを返す。
+// 例：
+//   a  == 1
+//   あ == 2
+//   漢 == 2
+//   ｂ == 漢2
 func GetLooksLength(text string) int {
 	length := 0
 	for _, v := range []rune(text) {
@@ -38,9 +46,13 @@ func GetLooksLength(text string) int {
 
 		if kind == width.EastAsianWide {
 			length += 2
-		} else {
-			length += 1
+			continue
 		}
+		if strings.Contains(zenkaku, string(v)) {
+			length += 2
+			continue
+		}
+		length += 1
 	}
 	return length
 }

--- a/cmd/PrintUtils.go
+++ b/cmd/PrintUtils.go
@@ -38,7 +38,7 @@ const zenkaku = "　ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴ
 //   a  == 1
 //   あ == 2
 //   漢 == 2
-//   ｂ == 漢2
+//   ｂ == 2
 func GetLooksLength(text string) int {
 	length := 0
 	for _, v := range []rune(text) {

--- a/cmd/PrintUtils_test.go
+++ b/cmd/PrintUtils_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import "testing"
+
+func TestGetLooksLength(t *testing.T) {
+	type TestData struct {
+		text   string
+		length int
+	}
+	testDatas := []TestData{
+		{text: "a", length: 1},
+		{text: "あ", length: 2},
+		{text: "漢", length: 2},
+		{text: "ａ", length: 2},
+		{text: "Ａ", length: 2},
+		{text: " ", length: 1},
+		{text: "　", length: 2},
+		{text: "あいうえお", length: 10},
+	}
+	for _, v := range testDatas {
+		l := GetLooksLength(v.text)
+		if v.length != l {
+			t.Errorf("文字列の長さが不一致:引数 = <%s>, 期待値 = %d, 実際 = %d", v.text, v.length, l)
+		}
+	}
+}


### PR DESCRIPTION
いつもシェル芸botでお世話になっております。

件名の通り、全角英数字と全角空白の時に 2 を加算するように修正しました。
テストコードにて値については検証済みです。

よろしくお願いいたします。