### PR TITLE
kanbanコマンドで標準入力と複数行の入力を処理できるようにした

### DIFF
--- a/cmd/kanban.go
+++ b/cmd/kanban.go
@@ -82,10 +82,8 @@ func PrintKanban(text string, offset int, gikoneko bool) {
 	var AA []string
 	AA = append(AA, fmt.Sprintf("|%s|", strings.Repeat(topString, maxLength/2)))
 	for _, t := range texts {
-		l := GetLooksLength(t)
-		if l < maxLength {
-			t = padSpace(t, maxLength)
-		}
+		// 看板の横幅に合わせて空白埋め
+		t = padSpace(t, maxLength)
 		s := fmt.Sprintf("|%s|", t)
 		AA = append(AA, s)
 	}

--- a/cmd/kanban.go
+++ b/cmd/kanban.go
@@ -67,23 +67,20 @@ func PrintKanban(text string, offset int, gikoneko bool) {
 	const topString = "￣"
 	const bottomString = "＿"
 
+	// テキストを改行文字で分割し、最長文字列に合わせて空白詰め
+	// 最長文字列の長さも返す
 	texts := strings.Split(text, "\n")
 	texts, textLen := makePaddedText(texts)
 
-	sideLength := 4
-	maxLength := 18
+	sideLength := 4 // テキストの横に確保しておきたい空白
+	maxLength := 18 // 看板の横幅
+	// デフォルト値よりも大きい問だけ幅を拡張する
 	if maxLength < textLen+sideLength {
 		maxLength = textLen + sideLength
 	}
 
-	boardPadFunc := func(t string, max int) string {
-		n := max / 2
-		line := strings.Repeat(t, n)
-		return "|" + line + "|"
-	}
-
 	var AA []string
-	AA = append(AA, boardPadFunc(topString, maxLength))
+	AA = append(AA, fmt.Sprintf("|%s|", strings.Repeat(topString, maxLength/2)))
 	for _, t := range texts {
 		l := GetLooksLength(t)
 		if l < maxLength {
@@ -93,10 +90,9 @@ func PrintKanban(text string, offset int, gikoneko bool) {
 		AA = append(AA, s)
 	}
 	AA = append(AA, fmt.Sprintf("|%s|", padSpace("制作・著作", maxLength)))
-	top := strings.Repeat(topString, (maxLength/2)-2)
-	AA = append(AA, fmt.Sprintf("|  %s  |", top))
+	AA = append(AA, fmt.Sprintf("|  %s  |", strings.Repeat(topString, (maxLength/2)-2)))
 	AA = append(AA, fmt.Sprintf("|%s|", padSpace(" Ｎ Ｈ Ｋ ", maxLength)))
-	AA = append(AA, boardPadFunc(bottomString, maxLength))
+	AA = append(AA, fmt.Sprintf("|%s|", strings.Repeat(bottomString, maxLength/2)))
 
 	if gikoneko {
 		AA = append(AA, fmt.Sprintf(" %s ", padSpace(" ∧∧  ||", maxLength)))

--- a/cmd/kanban.go
+++ b/cmd/kanban.go
@@ -68,16 +68,16 @@ func PrintKanban(text string, offset int, gikoneko bool) {
 	const bottomString = "＿"
 
 	texts := strings.Split(text, "\n")
-	texts, textLen := makeLooksTexts(texts)
+	texts, textLen := makePaddedText(texts)
 
 	sideLength := 4
-	maxLength := 10
+	maxLength := 16
 	if maxLength < textLen+sideLength {
 		maxLength = textLen + sideLength
 	}
 
 	boardPadFunc := func(t string, max int) string {
-		n := (max - 2) / 2
+		n := max / 2
 		line := strings.Repeat(t, n)
 		return "|" + line + "|"
 	}
@@ -85,24 +85,32 @@ func PrintKanban(text string, offset int, gikoneko bool) {
 	var AA []string
 	AA = append(AA, boardPadFunc(topString, maxLength))
 	for _, t := range texts {
-		s := fmt.Sprintf("| %s |", t)
+		l := GetLooksLength(t)
+		if l < maxLength {
+			t = padSpace(t, maxLength)
+		}
+		s := fmt.Sprintf("|%s|", t)
 		AA = append(AA, s)
 	}
-	AA = append(AA, fmt.Sprintf("|%s|", padSpace("制作・著作", maxLength-2)))
+	AA = append(AA, fmt.Sprintf("|%s|", padSpace("制作・著作", maxLength)))
 	AA = append(AA, boardPadFunc(topString, maxLength))
-	AA = append(AA, fmt.Sprintf("|%s|", padSpace(" Ｎ Ｈ Ｋ ", maxLength-2)))
+	AA = append(AA, fmt.Sprintf("|%s|", padSpace(" Ｎ Ｈ Ｋ ", maxLength)))
 	AA = append(AA, boardPadFunc(bottomString, maxLength))
 
 	if gikoneko {
-		AA = append(AA, fmt.Sprintf(" %s ", padSpace(" ∧∧  ||", maxLength-2)))
-		AA = append(AA, fmt.Sprintf(" %s ", padSpace("( ﾟдﾟ)||", maxLength-2)))
-		AA = append(AA, fmt.Sprintf(" %s ", padSpace("/　づΦ", maxLength-2)))
+		AA = append(AA, fmt.Sprintf(" %s ", padSpace(" ∧∧  ||", maxLength)))
+		AA = append(AA, fmt.Sprintf(" %s ", padSpace("( ﾟдﾟ)||", maxLength)))
+		AA = append(AA, fmt.Sprintf(" %s ", padSpace("/　づΦ", maxLength)))
 	}
 
 	PrintAA(AA, offset)
 }
 
-func makeLooksTexts(ts []string) ([]string, int) {
+func makePaddedText(ts []string) ([]string, int) {
+	if len(ts) < 1 {
+		return []string{}, 0
+	}
+
 	maxLength := 0
 
 	var texts = ts[:]
@@ -131,9 +139,17 @@ func makeLooksTexts(ts []string) ([]string, int) {
 		}
 	}
 
+	// 最長文字列自体は偶数に合わせているので
+	// もし奇数の最長値がセットされてたら修正
+	if maxLength%2 == 1 {
+		maxLength++
+	}
+
 	return texts, maxLength
 }
 
+// padSpace は前後を半角スペースで埋めた文字列を返す。
+// 文字列の長さは見た目上の長さで偶数でなければならない。
 func padSpace(t string, max int) string {
 	l := GetLooksLength(t)
 	diff := max - l

--- a/cmd/kanban.go
+++ b/cmd/kanban.go
@@ -71,7 +71,7 @@ func PrintKanban(text string, offset int, gikoneko bool) {
 	texts, textLen := makePaddedText(texts)
 
 	sideLength := 4
-	maxLength := 16
+	maxLength := 18
 	if maxLength < textLen+sideLength {
 		maxLength = textLen + sideLength
 	}
@@ -93,7 +93,8 @@ func PrintKanban(text string, offset int, gikoneko bool) {
 		AA = append(AA, s)
 	}
 	AA = append(AA, fmt.Sprintf("|%s|", padSpace("制作・著作", maxLength)))
-	AA = append(AA, boardPadFunc(topString, maxLength))
+	top := strings.Repeat(topString, (maxLength/2)-2)
+	AA = append(AA, fmt.Sprintf("|  %s  |", top))
 	AA = append(AA, fmt.Sprintf("|%s|", padSpace(" Ｎ Ｈ Ｋ ", maxLength)))
 	AA = append(AA, boardPadFunc(bottomString, maxLength))
 

--- a/cmd/kanban_test.go
+++ b/cmd/kanban_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import "testing"
+
+func TestMakePaddedText(t *testing.T) {
+	type TestData struct {
+		texts  []string
+		ret    []string
+		length int
+	}
+	testDatas := []TestData{
+		{texts: []string{"a", "bbbbb"}, ret: []string{"   a  ", " bbbbb"}, length: 6},
+		{texts: []string{"あいう", "えお"}, ret: []string{"あいう", " えお "}, length: 6},
+		{texts: []string{"", ""}, ret: []string{"", ""}, length: 0},
+		{texts: []string{}, ret: []string{}, length: 0},
+	}
+	for _, v := range testDatas {
+		ret, l := makePaddedText(v.texts)
+		for i, r := range ret {
+			text := v.texts[i]
+			if r != text {
+				t.Errorf("文字列が不一致:引数 = %v, 期待値 = %s, 実際 = %s", v.texts, r, text)
+			}
+		}
+		if v.length != l {
+			t.Errorf("最長文字列の長さが不一致:引数 = %v, 期待値 = %d, 実際 = %d", v.texts, v.length, l)
+		}
+	}
+}
+func TestPadSpace(t *testing.T) {
+	type TestData struct {
+		text string
+		max  int
+		ret  string
+	}
+	testDatas := []TestData{
+		{text: "a ", max: 2, ret: "a "},
+		{text: "a ", max: 4, ret: " a  "},
+		{text: "あ", max: 2, ret: "あ"},
+		{text: "あ", max: 4, ret: " あ "},
+	}
+	for _, v := range testDatas {
+		ret := padSpace(v.text, v.max)
+		if v.ret != ret {
+			t.Errorf("パディングされた文字列が不一致:引数text = <%s>, 引数max = <%d>, 期待値 = %s, 実際 = %s", v.text, v.max, v.ret, ret)
+		}
+	}
+}


### PR DESCRIPTION
kanbanに標準入力と複数行処理できるようにしてみました。
ご確認よろしくお願いします。

```
% cat << EOS | ./owari kanban -i --giko
Java言語
Go言語   
pipe heredoc> EOS

|￣￣￣￣￣￣￣￣￣|
|     Java言語     |
|      Go言語      |
|    制作・著作    |
|  ￣￣￣￣￣￣￣  |
|     Ｎ Ｈ Ｋ     |
|＿＿＿＿＿＿＿＿＿|
       ∧∧  ||      
      ( ﾟдﾟ)||      
       /　づΦ 
```