### PR TITLE
fix: NHKからOWRへの修正漏れ対応

### DIFF
--- a/aa/arts/kanban.go
+++ b/aa/arts/kanban.go
@@ -3,8 +3,9 @@ package arts
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/xztaityozx/owari/aa"
 	"strings"
+
+	"github.com/xztaityozx/owari/aa"
 )
 
 // Kanban は
@@ -67,7 +68,7 @@ func (k *Kanban) SetReverse(b bool) {
 
 func (k *Kanban) SetAuthor(author string) {
 	if len(author) == 0 {
-		k.author = "Ｎ Ｈ Ｋ"
+		k.author = "Ｏ Ｗ Ｒ"
 	} else {
 		k.author = author
 	}

--- a/aa/arts/kanban_test.go
+++ b/aa/arts/kanban_test.go
@@ -1,9 +1,10 @@
 package arts
 
 import (
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewKanban(t *testing.T) {
@@ -19,6 +20,7 @@ func TestNewKanban(t *testing.T) {
 func TestKanban_Load(t *testing.T) {
 	t.Run("装飾がないやつ", func(t *testing.T) {
 		k := NewKanban(nil)
+		k.SetAuthor("")
 		assert.NotNil(t, k)
 		err := k.Load("default")
 		assert.Nil(t, err)

--- a/cmd/kanban.go
+++ b/cmd/kanban.go
@@ -22,10 +22,11 @@ package cmd
 
 import (
 	"bufio"
-	"github.com/spf13/cobra"
-	"github.com/xztaityozx/owari/aa/arts"
 	"log"
 	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/xztaityozx/owari/aa/arts"
 )
 
 // kanbanCmd represents the kanban command
@@ -102,7 +103,7 @@ func init() {
 	kanbanCmd.Flags().BoolP("stdin", "i", false, "標準入力を受取ります")
 	kanbanCmd.Flags().Bool("konata", false, "こなた")
 	kanbanCmd.Flags().BoolP("textimg", "t", false, "textimg用に出力を整えます。実際には--font=NotoSansCJKのShortHandです")
-	kanbanCmd.Flags().StringP("author", "a", "Ｎ Ｈ Ｋ", "制作・著作者を指定します")
+	kanbanCmd.Flags().StringP("author", "a", "Ｏ Ｗ Ｒ", "制作・著作者を指定します")
 	kanbanCmd.Flags().StringP("font", "f", "default", "指定したフォントでの描画用に出力を整えます")
 	kanbanCmd.Flags().Bool("reverse", false, "ギコ猫を反転します")
 	kanbanCmd.Flags().Bool("twin", false, "ギコ猫を二匹に増やします")


### PR DESCRIPTION
`$ owari kan` の時だけ元のままだったようなので、修正しました